### PR TITLE
Rename functions to fix errors when compiling and executing

### DIFF
--- a/src/09_sleep_lib.c
+++ b/src/09_sleep_lib.c
@@ -21,6 +21,6 @@ static int u_sleep(lua_State *L)
 int luaopen_msleep(lua_State *L)
 {
     lua_register(L, "sleep", s_sleep);
-    lua_register(L, "msleep", m_sleep);
+    lua_register(L, "msleep", u_sleep);
     return 0;
 }

--- a/src/test_sleep.lua
+++ b/src/test_sleep.lua
@@ -14,5 +14,5 @@ local end_time = os.time()
 print(string.format("After sleep(1), time is %d", end_time))
 
 print(string.format("First  interval = %d seconds", mid_time - start_time))
-pritn(string.format("Second interval = %d seconds", end_time - mid_time))
+print(string.format("Second interval = %d seconds", end_time - mid_time))
 print(string.format("Whole  interval = %d seconds", end_time - start_time))


### PR DESCRIPTION
I changed the name of two functions that were wrong and giving error at the time of compilation and execution of the code